### PR TITLE
add selinux policy to howdy-beta

### DIFF
--- a/howdy-beta/howdy.spec
+++ b/howdy-beta/howdy.spec
@@ -15,6 +15,7 @@ URL:            %{forgeurl}
 Source0:        %{forgesource}
 Source1:        howdy_profile.sh
 Source2:        howdy_profile.csh
+Source3:        howdy.te
 Source10:       https://github.com/davisking/dlib-models/raw/master/dlib_face_recognition_resnet_model_v1.dat.bz2
 Source11:       https://github.com/davisking/dlib-models/raw/master/mmod_human_face_detector.dat.bz2
 Source12:       https://github.com/davisking/dlib-models/raw/master/shape_predictor_5_face_landmarks.dat.bz2
@@ -25,6 +26,8 @@ BuildRequires:  gcc-c++
 BuildRequires:  meson
 BuildRequires:  bzip2
 BuildRequires:  python3-devel
+BuildRequires:  selinux-policy
+BuildRequires:  policycoreutils-devel
 
 BuildRequires:  pkgconfig(INIReader)
 BuildRequires:  pkgconfig(libevdev)
@@ -83,6 +86,11 @@ chmod 0755 howdy/src/compare.py
 # Disable downloading dlib-data files
 sed -i "/install_data('dlib-data\/install.sh',.*/d"  howdy/src/meson.build
 
+# Compile SELinux policy module
+cp %{S:3} howdy.te
+checkmodule -M -m -o howdy.mod howdy.te
+semodule_package -o howdy.pp -m howdy.mod
+
 %build
 %meson \
     -Ddlib_data_dir=%{_datadir}/%{name}/dlib-data/ \
@@ -112,6 +120,28 @@ mkdir -p   %{buildroot}%{_sysconfdir}/%{name}/models/
 # install dlib-data files
 install -Dm 0644 howdy/src/dlib-data/*.dat -t %{buildroot}%{_datadir}/%{name}/dlib-data/
 
+# install the SELinux policy
+install -Dm 0644 howdy.pp %{buildroot}%{_datadir}/selinux/targeted/contexts/files/howdy.pp
+
+%post
+# Install SELinux module
+if command -v sestatus >/dev/null 2>&1 && sestatus | grep -q 'SELinux status:.*enabled'; then
+    # Check if the SELinux module is already installed
+    if ! semodule -l | grep -q howdy; then
+        # Load the SELinux policy module if it's not already loaded
+        semodule -i %{_datadir}/selinux/targeted/contexts/files/howdy.pp
+    fi
+fi
+
+%postun
+# Uninstall SELinux module
+if command -v sestatus >/dev/null 2>&1 && sestatus | grep -q 'SELinux status:.*enabled'; then
+    # Check if the howdy module is installed
+    if semodule -l | grep -q howdy; then
+        # Remove the howdy SELinux policy module
+        semodule -d howdy
+    fi
+fi
 
 %files
 %license LICENSE
@@ -129,6 +159,7 @@ install -Dm 0644 howdy/src/dlib-data/*.dat -t %{buildroot}%{_datadir}/%{name}/dl
 %dir %{_sysconfdir}/%{name}/models/
 %config(noreplace) %{_sysconfdir}/%{name}/config.ini
 %config(noreplace) %{_sysconfdir}/profile.d/%{name}.*
+%{_datadir}/selinux/*/contexts/files/howdy.pp
 
 %files gtk
 %{_bindir}/%{name}-gtk

--- a/howdy-beta/howdy.te
+++ b/howdy-beta/howdy.te
@@ -1,0 +1,10 @@
+module howdy 1.0;
+
+require {
+        type xdm_t;
+        type v4l_device_t;
+        class chr_file map;
+}
+
+#============= xdm_t ==============
+allow xdm_t v4l_device_t:chr_file map;


### PR DESCRIPTION
Trying to use howdy-beta on my Fedora 41 system results in SELinux /var/log/audit/audit.log errors like:

```
type=AVC msg=audit(1731249683.384:270): avc:  denied  { map } for  pid=2191 comm="python3" path="/dev/video2" dev="devtmpfs" ino=975 scontext=system_u:system_r:xdm_t:s0-s0:c0.c1023 tcontext=system_u:object_r:v4l_device_t:s0 tclass=chr_file permissive=0
```

I used `audit2allow` to create a working policy and have included it in the package here.